### PR TITLE
Add tournament management and player fixes

### DIFF
--- a/src/main/java/com/geo/challenge/constant/ConstantValues.java
+++ b/src/main/java/com/geo/challenge/constant/ConstantValues.java
@@ -3,4 +3,5 @@ package com.geo.challenge.constant;
 public class ConstantValues {
     public static final String MALE = "MALE";
     public static final String FEMALE = "FEMALE";
+    public static final String GEOPAGOS = "/geopagos";
 }

--- a/src/main/java/com/geo/challenge/constant/ErrorCodes.java
+++ b/src/main/java/com/geo/challenge/constant/ErrorCodes.java
@@ -12,7 +12,19 @@ public enum ErrorCodes {
     PLAYER_STRENGTH_ERROR("GEO0009", "La fuerza del jugador debe ser un número entero entre 0 y 100"),
     PLAYER_SPEED_ERROR("GEO0010", "La velocidad del jugador debe ser un número decimal entre 0 y 50 km/h"),
     ERROR_DELETING_PLAYER("GEO0011", "Error inesperado al eliminar el Jugador con ID: %s"),
-    PLAYER_NAME_DUPLICATED("GEO0012", "Ya existe un jugador con el nombre: %s y no debe repetirse");
+    PLAYER_NAME_DUPLICATED("GEO0012", "Ya existe un jugador con el nombre: %s y no debe repetirse"),
+    TOURNAMENT_NAME_ERROR("GEO0013", "El nombre del torneo no puede ser nulo"),
+    TOURNAMENT_TYPE_ERROR("GEO0014", "El tipo de torneo debe ser MALE (masculino) o FEMALE (femenino)"),
+    TOURNAMENT_DATE_ERROR("GEO0015", "La fecha del torneo debe tener un formato DD/MM/YYYY válido"),
+    TOURNAMENT_COMPETITORS_ERROR("GEO0016", "El número de competidores debe ser un número entero y potencia de 2"),
+    INSUFFICIENT_PARAMETERS("GEO0017", "Para consultar un torneo debe indicar el Nombre o la Fecha minimamente"),
+    TOURNAMENT_NAME_DUPLICATED("GEO0018", "Ya existe un torneo con el nombre: %s y no debe repetirse"),
+    MULTIPLE_RESULT_ERROR("GEO0019", "Existe más de un torneo para esta Fecha, por favor ingrese el Nombre y/o el Tipo"),
+    TOURNAMENT_NOT_FOUND("GEO0020", "No se encontró un torneo con los parámetros especificados"),
+    TOURNAMENT_NOT_ENOUGH_DATA("GEO0021", "No hay suficientes jugadores en la base de datos"),
+    EMPTY_PLAYER_LIST("GEO0022", "Debe indicar que jugadores participarán del torneo (la cantidad debe ser potencia de 2)"),
+    PARTIAL_PLAYER_DATA("GEO0023", "Algunos de los ID de jugadores ingresados no se encontraron en la base de datos"),
+    UNEXPECTED_ERROR("GEO0024", "Ocurrió un error inesperado procesando los datos del torneo, por favor intentelo nuevamente");
 
     private final String code;
     private final String description;

--- a/src/main/java/com/geo/challenge/controller/PlayerController.java
+++ b/src/main/java/com/geo/challenge/controller/PlayerController.java
@@ -6,8 +6,11 @@ import com.geo.challenge.service.PlayerManagementService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import static com.geo.challenge.constant.ConstantValues.GEOPAGOS;
+
 @RestController
-@RequestMapping("/geopagos")
+@RequestMapping(GEOPAGOS)
+@CrossOrigin(origins = "*")
 public class PlayerController {
 
     private final PlayerManagementService playerService;
@@ -17,31 +20,31 @@ public class PlayerController {
     }
 
     @GetMapping("/player/{player-id}")
-    ResponseEntity<PlayerResponse> getPlayer(@PathVariable("player-id") Integer playerId) {
+    public ResponseEntity<PlayerResponse> getPlayer(@PathVariable("player-id") Integer playerId) {
         PlayerResponse response = playerService.getPlayer(playerId);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/player")
-    ResponseEntity<PlayerResponse> listPlayers() {
+    public ResponseEntity<PlayerResponse> listPlayers() {
         PlayerResponse response = playerService.getAllPlayers();
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/player")
-    ResponseEntity<PlayerResponse> addPlayer(@RequestBody PlayerRequest request) {
+    public ResponseEntity<PlayerResponse> addPlayer(@RequestBody PlayerRequest request) {
         PlayerResponse response = playerService.createPlayer(request);
         return ResponseEntity.ok(response);
     }
 
     @PutMapping("/player/{player-id}")
-    ResponseEntity<PlayerResponse> updatePlayer(@RequestBody PlayerRequest request, @PathVariable("player-id") Integer playerId) {
+    public ResponseEntity<PlayerResponse> updatePlayer(@RequestBody PlayerRequest request, @PathVariable("player-id") Integer playerId) {
         PlayerResponse response = playerService.updatePlayer(request, playerId);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/player/{player-id}")
-    ResponseEntity<PlayerResponse> deletePlayer(@PathVariable("player-id") Integer playerId) {
+    public ResponseEntity<PlayerResponse> deletePlayer(@PathVariable("player-id") Integer playerId) {
         playerService.deletePlayer(playerId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/geo/challenge/controller/TournamentController.java
+++ b/src/main/java/com/geo/challenge/controller/TournamentController.java
@@ -1,4 +1,41 @@
 package com.geo.challenge.controller;
 
+import com.geo.challenge.dto.request.TournamentGeneratorRequest;
+import com.geo.challenge.dto.request.TournamentRandomGeneratorRequest;
+import com.geo.challenge.dto.request.TournamentRequest;
+import com.geo.challenge.dto.response.TournamentResponse;
+import com.geo.challenge.service.TournamentManagementService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static com.geo.challenge.constant.ConstantValues.GEOPAGOS;
+
+@RestController
+@RequestMapping(GEOPAGOS)
+@CrossOrigin(origins = "*")
 public class TournamentController {
+
+    private final TournamentManagementService tournamentManagementService;
+
+    public TournamentController(TournamentManagementService tournamentManagementService) {
+        this.tournamentManagementService = tournamentManagementService;
+    }
+
+    @PostMapping("/tournament/random")
+    public ResponseEntity<TournamentResponse> generateRandomTournament(@RequestBody TournamentRandomGeneratorRequest request) {
+        TournamentResponse tournament = tournamentManagementService.generateRandomTournament(request);
+        return ResponseEntity.ok(tournament);
+    }
+
+    @PostMapping("/tournament")
+    public ResponseEntity<TournamentResponse> generateTournament(@RequestBody TournamentGeneratorRequest request) {
+        TournamentResponse tournament = tournamentManagementService.generateTournament(request);
+        return ResponseEntity.ok(tournament);
+    }
+
+    @GetMapping("/tournament")
+    public ResponseEntity<TournamentResponse> getTournament(@RequestBody TournamentRequest request) {
+        TournamentResponse tournament = tournamentManagementService.getTournament(request);
+        return ResponseEntity.ok(tournament);
+    }
 }

--- a/src/main/java/com/geo/challenge/dto/request/TournamentGeneratorRequest.java
+++ b/src/main/java/com/geo/challenge/dto/request/TournamentGeneratorRequest.java
@@ -1,0 +1,24 @@
+package com.geo.challenge.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class TournamentGeneratorRequest extends TournamentRequest {
+
+    @JsonProperty("player_ids")
+    private List<Integer> playerIds;
+
+    public TournamentGeneratorRequest(String name, String type, String date, List<Integer> playerIds) {
+        super(name, type, date);
+        this.playerIds = playerIds;
+    }
+
+    public List<Integer> getPlayerIds() {
+        return playerIds;
+    }
+
+    public void setPlayerIds(List<Integer> playerIds) {
+        this.playerIds = playerIds;
+    }
+}

--- a/src/main/java/com/geo/challenge/dto/request/TournamentRandomGeneratorRequest.java
+++ b/src/main/java/com/geo/challenge/dto/request/TournamentRandomGeneratorRequest.java
@@ -1,0 +1,22 @@
+package com.geo.challenge.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TournamentRandomGeneratorRequest extends TournamentRequest {
+
+    @JsonProperty("competitors")
+    private Integer competitors;
+
+    public TournamentRandomGeneratorRequest(String name, String type, String date, Integer competitors) {
+        super(name, type, date);
+        this.competitors = competitors;
+    }
+
+    public Integer getCompetitors() {
+        return competitors;
+    }
+
+    public void setCompetitors(Integer competitors) {
+        this.competitors = competitors;
+    }
+}

--- a/src/main/java/com/geo/challenge/dto/request/TournamentRequest.java
+++ b/src/main/java/com/geo/challenge/dto/request/TournamentRequest.java
@@ -1,4 +1,45 @@
 package com.geo.challenge.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class TournamentRequest {
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("type")
+    private String type;
+
+    @JsonProperty("date")
+    private String date;
+
+    public TournamentRequest(String name, String type, String date) {
+        this.name = name;
+        this.type = type;
+        this.date = date;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public void setDate(String date) {
+        this.date = date;
+    }
 }

--- a/src/main/java/com/geo/challenge/dto/response/TournamentGameResponse.java
+++ b/src/main/java/com/geo/challenge/dto/response/TournamentGameResponse.java
@@ -1,0 +1,47 @@
+package com.geo.challenge.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TournamentGameResponse {
+
+    @JsonProperty("game_id")
+    private Integer gameId;
+
+    @JsonProperty("winner_name")
+    private String winner;
+
+    @JsonProperty("loser_name")
+    private String loser;
+
+    public TournamentGameResponse() { }
+
+    public TournamentGameResponse(Integer gameId, String winner, String loser) {
+        this.gameId = gameId;
+        this.winner = winner;
+        this.loser = loser;
+    }
+
+    public Integer getGameId() {
+        return gameId;
+    }
+
+    public void setGameId(Integer gameId) {
+        this.gameId = gameId;
+    }
+
+    public String getWinner() {
+        return winner;
+    }
+
+    public void setWinner(String winner) {
+        this.winner = winner;
+    }
+
+    public String getLoser() {
+        return loser;
+    }
+
+    public void setLoser(String loser) {
+        this.loser = loser;
+    }
+}

--- a/src/main/java/com/geo/challenge/dto/response/TournamentPhaseResponse.java
+++ b/src/main/java/com/geo/challenge/dto/response/TournamentPhaseResponse.java
@@ -1,0 +1,32 @@
+package com.geo.challenge.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class TournamentPhaseResponse {
+
+    @JsonProperty("phase_number")
+    private Integer phaseNumber;
+
+    @JsonProperty("phase_games")
+    private List<TournamentGameResponse> phaseGames;
+
+    public TournamentPhaseResponse() { }
+
+    public Integer getPhaseNumber() {
+        return phaseNumber;
+    }
+
+    public void setPhaseNumber(Integer phaseNumber) {
+        this.phaseNumber = phaseNumber;
+    }
+
+    public List<TournamentGameResponse> getPhaseGames() {
+        return phaseGames;
+    }
+
+    public void setPhaseGames(List<TournamentGameResponse> phaseGames) {
+        this.phaseGames = phaseGames;
+    }
+}

--- a/src/main/java/com/geo/challenge/dto/response/TournamentResponse.java
+++ b/src/main/java/com/geo/challenge/dto/response/TournamentResponse.java
@@ -1,4 +1,84 @@
 package com.geo.challenge.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.geo.challenge.dto.AbstractPlayer;
+
+import java.util.ArrayList;
+import java.util.List;
+
 public class TournamentResponse {
+
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("type")
+    private String type;
+    @JsonProperty("competitors")
+    private Integer competitors;
+    @JsonProperty("date")
+    private String date;
+    @JsonProperty("winner")
+    AbstractPlayer winner;
+    @JsonProperty("phases")
+    List<TournamentPhaseResponse> phases;
+
+    public TournamentResponse() {
+        this.phases = new ArrayList<>();
+    }
+
+    public TournamentResponse(String name, String type, Integer competitors, String date, AbstractPlayer winner, List<TournamentPhaseResponse> phases) {
+        this.name = name;
+        this.type = type;
+        this.competitors = competitors;
+        this.date = date;
+        this.winner = winner;
+        this.phases = phases;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Integer getCompetitors() {
+        return competitors;
+    }
+
+    public void setCompetitors(Integer competitors) {
+        this.competitors = competitors;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public void setDate(String date) {
+        this.date = date;
+    }
+
+    public AbstractPlayer getWinner() {
+        return winner;
+    }
+
+    public void setWinner(AbstractPlayer winner) {
+        this.winner = winner;
+    }
+
+    public List<TournamentPhaseResponse> getPhases() {
+        return phases;
+    }
+
+    public void setPhases(List<TournamentPhaseResponse> phases) {
+        this.phases = phases;
+    }
 }

--- a/src/main/java/com/geo/challenge/mapper/TournamentMapper.java
+++ b/src/main/java/com/geo/challenge/mapper/TournamentMapper.java
@@ -1,0 +1,9 @@
+package com.geo.challenge.mapper;
+
+import com.geo.challenge.dto.response.TournamentResponse;
+import com.geo.challenge.model.Tournament;
+
+public interface TournamentMapper {
+
+    TournamentResponse tournamentToTournamentResponse(Tournament tournament);
+}

--- a/src/main/java/com/geo/challenge/mapper/impl/TournamentMapperImpl.java
+++ b/src/main/java/com/geo/challenge/mapper/impl/TournamentMapperImpl.java
@@ -1,0 +1,42 @@
+package com.geo.challenge.mapper.impl;
+
+import com.geo.challenge.dto.response.TournamentGameResponse;
+import com.geo.challenge.dto.response.TournamentPhaseResponse;
+import com.geo.challenge.dto.response.TournamentResponse;
+import com.geo.challenge.mapper.PlayerMapper;
+import com.geo.challenge.mapper.TournamentMapper;
+import com.geo.challenge.model.Tournament;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Collectors;
+
+@Component
+public class TournamentMapperImpl implements TournamentMapper {
+
+    private final PlayerMapper playerMapper;
+
+    public TournamentMapperImpl(PlayerMapper playerMapper) {
+        this.playerMapper = playerMapper;
+    }
+
+    @Override
+    public TournamentResponse tournamentToTournamentResponse(Tournament tournament) {
+        TournamentResponse tournamentResponse = new TournamentResponse();
+        tournamentResponse.setName(tournament.getName());
+        tournamentResponse.setDate(tournament.getDate().toString());
+        tournamentResponse.setType(tournament.getType());
+        tournamentResponse.setCompetitors(tournament.getCompetitors());
+        tournamentResponse.setWinner(playerMapper.playerToPlayerDTO(tournament.getWinner()));
+
+        tournament.getPhases().forEach(phase -> {
+            TournamentPhaseResponse newPhase = new TournamentPhaseResponse();
+            newPhase.setPhaseNumber(phase.getPhaseNumber());
+            newPhase.setPhaseGames(phase.getGames().stream().map(game ->
+                    new TournamentGameResponse(game.getGameId(), game.getWinner().getName(), game.getLoser().getName())).collect(Collectors.toList()));
+            tournamentResponse.getPhases().add(newPhase);
+        });
+
+        return tournamentResponse;
+    }
+
+}

--- a/src/main/java/com/geo/challenge/model/Player.java
+++ b/src/main/java/com/geo/challenge/model/Player.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 
 @Entity
 @Table(name = "player")
-public class Player {
+public class Player implements Cloneable {
 
     @Id
     @Column(name = "player_id")
@@ -95,5 +95,10 @@ public class Player {
 
     public void setActive(Boolean active) {
         this.active = active;
+    }
+
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        return super.clone();
     }
 }

--- a/src/main/java/com/geo/challenge/model/Tournament.java
+++ b/src/main/java/com/geo/challenge/model/Tournament.java
@@ -3,6 +3,8 @@ package com.geo.challenge.model;
 import jakarta.persistence.*;
 
 import java.sql.Date;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "tournament")
@@ -12,23 +14,19 @@ public class Tournament {
     @Column(name = "tournament_id")
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Integer tournamentId;
-
-    private String description;
+    @Column(unique = true)
+    private String name;
     private Date date;
     private String type;
-
-    @OneToOne
-    @JoinColumn(referencedColumnName = "player_id")
+    private Integer competitors;
+    @ManyToOne
+    @JoinColumn(name = "winner_player_id")
     private Player winner;
+    @OneToMany(mappedBy = "tournament")
+    private List<TournamentPhase> phases;
 
-    public Tournament() { }
-
-    public Tournament(Integer tournamentId, String description, Date date, String type, Player winner) {
-        this.tournamentId = tournamentId;
-        this.description = description;
-        this.date = date;
-        this.type = type;
-        this.winner = winner;
+    public Tournament() {
+        this.phases = new ArrayList<>();
     }
 
     public Integer getTournamentId() {
@@ -39,12 +37,12 @@ public class Tournament {
         this.tournamentId = tournamentId;
     }
 
-    public String getDescription() {
-        return description;
+    public String getName() {
+        return name;
     }
 
-    public void setDescription(String description) {
-        this.description = description;
+    public void setName(String name) {
+        this.name = name;
     }
 
     public Date getDate() {
@@ -63,6 +61,14 @@ public class Tournament {
         this.type = type;
     }
 
+    public Integer getCompetitors() {
+        return competitors;
+    }
+
+    public void setCompetitors(Integer competitors) {
+        this.competitors = competitors;
+    }
+
     public Player getWinner() {
         return winner;
     }
@@ -70,4 +76,18 @@ public class Tournament {
     public void setWinner(Player winner) {
         this.winner = winner;
     }
+
+    public List<TournamentPhase> getPhases() {
+        return phases;
+    }
+
+    public void setPhases(List<TournamentPhase> phases) {
+        this.phases = phases;
+    }
+
+    public void addPhase(TournamentPhase phase) {
+        this.phases.add(phase);
+    }
+
+
 }

--- a/src/main/java/com/geo/challenge/model/TournamentPhase.java
+++ b/src/main/java/com/geo/challenge/model/TournamentPhase.java
@@ -2,6 +2,9 @@ package com.geo.challenge.model;
 
 import jakarta.persistence.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name = "tournament_phase")
 public class TournamentPhase {
@@ -17,12 +20,11 @@ public class TournamentPhase {
 
     private Integer phaseNumber;
 
-    public TournamentPhase() { }
+    @OneToMany(mappedBy = "phase")
+    private List<TournamentPhaseGame> games;
 
-    public TournamentPhase(Integer phaseId, Tournament tournament, Integer phaseNumber) {
-        this.phaseId = phaseId;
-        this.tournament = tournament;
-        this.phaseNumber = phaseNumber;
+    public TournamentPhase() {
+        this.games = new ArrayList<>();
     }
 
     public Integer getPhaseId() {
@@ -48,4 +50,17 @@ public class TournamentPhase {
     public void setPhaseNumber(Integer phaseNumber) {
         this.phaseNumber = phaseNumber;
     }
+
+    public List<TournamentPhaseGame> getGames() {
+        return games;
+    }
+
+    public void setGames(List<TournamentPhaseGame> games) {
+        this.games = games;
+    }
+
+    public void addGame(TournamentPhaseGame game) {
+        this.games.add(game);
+    }
+
 }

--- a/src/main/java/com/geo/challenge/repository/PlayerRepository.java
+++ b/src/main/java/com/geo/challenge/repository/PlayerRepository.java
@@ -2,6 +2,8 @@ package com.geo.challenge.repository;
 
 import com.geo.challenge.model.Player;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +15,12 @@ public interface PlayerRepository extends JpaRepository<Player, Integer> {
     List<Player> findByActive(Boolean active);
 
     Boolean existsByPlayerIdAndActive(Integer playerId, Boolean active);
+
+    Integer countByGender(String gender);
+
+    @Query(value = "SELECT * FROM Player WHERE gender = :gender ORDER BY RANDOM() LIMIT :quantity", nativeQuery = true)
+    List<Player> findRandomPlayers(@Param("quantity") Integer quantity, @Param("gender") String gender);
+
+    @Query(value = "SELECT * FROM Player WHERE gender = :gender AND player_id IN :playerIds ORDER BY RANDOM()", nativeQuery = true)
+    List<Player> findPlayersByIds(@Param("playerIds") List<Integer> playerIds, @Param("gender") String gender);
 }

--- a/src/main/java/com/geo/challenge/repository/TournamentRepository.java
+++ b/src/main/java/com/geo/challenge/repository/TournamentRepository.java
@@ -3,5 +3,20 @@ package com.geo.challenge.repository;
 import com.geo.challenge.model.Tournament;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Date;
+
 public interface TournamentRepository extends JpaRepository<Tournament, Integer> {
+
+    Boolean existsByName(String name);
+
+    Integer countByDate(Date date);
+
+    Integer countByDateAndType(Date date, String type);
+
+    Tournament findByDate(Date date);
+
+    Tournament findByDateAndType(Date date, String type);
+
+    Tournament findByName(String name);
+
 }

--- a/src/main/java/com/geo/challenge/service/PlayerService.java
+++ b/src/main/java/com/geo/challenge/service/PlayerService.java
@@ -14,4 +14,9 @@ public interface PlayerService {
 
     Boolean exists(Integer playerId);
 
+    List<Player> findRandomPlayers(Integer quantity, String gender);
+
+    List<Player> findPlayersByIds(List<Integer> playerIds, String gender);
+
+    Integer countByGender(String gender);
 }

--- a/src/main/java/com/geo/challenge/service/RequestValidator.java
+++ b/src/main/java/com/geo/challenge/service/RequestValidator.java
@@ -1,12 +1,18 @@
 package com.geo.challenge.service;
 
 import com.geo.challenge.dto.request.PlayerRequest;
+import com.geo.challenge.dto.request.TournamentGeneratorRequest;
+import com.geo.challenge.dto.request.TournamentRandomGeneratorRequest;
 import com.geo.challenge.dto.request.TournamentRequest;
 
 public interface RequestValidator {
 
     void validatePlayerRequest(PlayerRequest request);
 
-    Boolean isTournamentRequestValid(TournamentRequest request);
+    void validateTournamentRequest(TournamentRequest request);
+
+    void validateTournamentRandomGeneratorRequest(TournamentRandomGeneratorRequest request);
+
+    void validateTournamentGeneratorRequest(TournamentGeneratorRequest request);
 
 }

--- a/src/main/java/com/geo/challenge/service/TournamentManagementService.java
+++ b/src/main/java/com/geo/challenge/service/TournamentManagementService.java
@@ -1,0 +1,16 @@
+package com.geo.challenge.service;
+
+import com.geo.challenge.dto.request.TournamentGeneratorRequest;
+import com.geo.challenge.dto.request.TournamentRandomGeneratorRequest;
+import com.geo.challenge.dto.request.TournamentRequest;
+import com.geo.challenge.dto.response.TournamentResponse;
+
+public interface TournamentManagementService {
+
+    TournamentResponse generateRandomTournament(TournamentRandomGeneratorRequest request);
+
+    TournamentResponse generateTournament(TournamentGeneratorRequest request);
+
+    TournamentResponse getTournament(TournamentRequest request);
+
+}

--- a/src/main/java/com/geo/challenge/service/TournamentService.java
+++ b/src/main/java/com/geo/challenge/service/TournamentService.java
@@ -1,0 +1,24 @@
+package com.geo.challenge.service;
+
+import com.geo.challenge.model.Tournament;
+import com.geo.challenge.model.TournamentPhase;
+
+import java.util.List;
+
+public interface TournamentService {
+
+    Boolean existsByName(String name);
+
+    Integer countByDate(String date);
+
+    Integer countByDateAndType(String date, String type);
+
+    Tournament findByDate(String date);
+
+    Tournament findByDateAndType(String date, String type);
+
+    Tournament findByName(String name);
+
+    Tournament save(Tournament tournament);
+
+}

--- a/src/main/java/com/geo/challenge/service/impl/PlayerServiceImpl.java
+++ b/src/main/java/com/geo/challenge/service/impl/PlayerServiceImpl.java
@@ -25,7 +25,7 @@ public class PlayerServiceImpl implements PlayerService {
         try {
             return playerRepository.save(player);
         } catch (DataIntegrityViolationException ex) {
-            throw new PlayerException(PLAYER_NAME_DUPLICATED.getCode(), PLAYER_NAME_DUPLICATED.getDescription());
+            throw new PlayerException(PLAYER_NAME_DUPLICATED.getCode(), String.format(PLAYER_NAME_DUPLICATED.getDescription(), player.getName()));
         }
     }
 
@@ -42,5 +42,20 @@ public class PlayerServiceImpl implements PlayerService {
     @Override
     public Boolean exists(Integer playerId) {
         return playerRepository.existsByPlayerIdAndActive(playerId, true);
+    }
+
+    @Override
+    public List<Player> findRandomPlayers(Integer quantity, String gender) {
+        return playerRepository.findRandomPlayers(quantity, gender);
+    }
+
+    @Override
+    public List<Player> findPlayersByIds(List<Integer> playerIds, String gender) {
+        return playerRepository.findPlayersByIds(playerIds, gender);
+    }
+
+    @Override
+    public Integer countByGender(String gender) {
+        return playerRepository.countByGender(gender);
     }
 }

--- a/src/main/java/com/geo/challenge/service/impl/RequestValidatorImpl.java
+++ b/src/main/java/com/geo/challenge/service/impl/RequestValidatorImpl.java
@@ -1,11 +1,16 @@
 package com.geo.challenge.service.impl;
 
 import com.geo.challenge.dto.request.PlayerRequest;
+import com.geo.challenge.dto.request.TournamentGeneratorRequest;
+import com.geo.challenge.dto.request.TournamentRandomGeneratorRequest;
 import com.geo.challenge.dto.request.TournamentRequest;
 import com.geo.challenge.exception.PlayerException;
+import com.geo.challenge.exception.TournamentException;
 import com.geo.challenge.service.RequestValidator;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 
+import java.time.LocalDate;
 import java.util.Objects;
 
 import static com.geo.challenge.constant.ConstantValues.FEMALE;
@@ -35,8 +40,65 @@ public class RequestValidatorImpl implements RequestValidator {
     }
 
     @Override
-    public Boolean isTournamentRequestValid(TournamentRequest request) {
-        return true;
+    public void validateTournamentRequest(TournamentRequest request) {
+        boolean isName = !Objects.isNull(request.getName());
+        boolean isDate = !Objects.isNull(request.getDate());
+        boolean isType = !Objects.isNull(request.getType());
+
+        if (isName && request.getName().isBlank())
+            throw new TournamentException(TOURNAMENT_NAME_ERROR.getCode(), TOURNAMENT_NAME_ERROR.getDescription());
+        if (isDate && !isValidDate(request.getDate()))
+            throw new TournamentException(TOURNAMENT_DATE_ERROR.getCode(), TOURNAMENT_DATE_ERROR.getDescription());
+        if (isType && !request.getType().equalsIgnoreCase(MALE) && !request.getType().equalsIgnoreCase(FEMALE))
+            throw new TournamentException(TOURNAMENT_TYPE_ERROR.getCode(), TOURNAMENT_TYPE_ERROR.getDescription());
+
+        if (!isName && !isDate)
+            throw new TournamentException(INSUFFICIENT_PARAMETERS.getCode(), INSUFFICIENT_PARAMETERS.getDescription());
     }
 
+    @Override
+    public void validateTournamentRandomGeneratorRequest(TournamentRandomGeneratorRequest request) {
+        validateCommonFields(request.getName(), request.getType(), request.getDate());
+        if (Objects.isNull(request.getCompetitors()) || !isValidCompetitorsQuantity(request.getCompetitors()))
+            throw new TournamentException(TOURNAMENT_COMPETITORS_ERROR.getCode(), TOURNAMENT_COMPETITORS_ERROR.getDescription());
+    }
+
+    @Override
+    public void validateTournamentGeneratorRequest(TournamentGeneratorRequest request) {
+        validateCommonFields(request.getName(), request.getType(), request.getDate());
+        if (CollectionUtils.isEmpty(request.getPlayerIds()))
+            throw new TournamentException(EMPTY_PLAYER_LIST.getCode(), EMPTY_PLAYER_LIST.getDescription());
+        if (!isValidCompetitorsQuantity(request.getPlayerIds().size()))
+            throw new TournamentException(TOURNAMENT_COMPETITORS_ERROR.getCode(), TOURNAMENT_COMPETITORS_ERROR.getDescription());
+    }
+
+    private void validateCommonFields(String name, String type, String date) {
+        if (Objects.isNull(name) || name.isBlank())
+            throw new TournamentException(TOURNAMENT_NAME_ERROR.getCode(), TOURNAMENT_NAME_ERROR.getDescription());
+        if (Objects.isNull(type) || (!type.equalsIgnoreCase(MALE) && !type.equalsIgnoreCase(FEMALE)))
+            throw new TournamentException(TOURNAMENT_TYPE_ERROR.getCode(), TOURNAMENT_TYPE_ERROR.getDescription());
+        if (Objects.isNull(date) || !isValidDate(date))
+            throw new TournamentException(TOURNAMENT_DATE_ERROR.getCode(), TOURNAMENT_DATE_ERROR.getDescription());
+    }
+
+    private Boolean isValidDate(String date) {
+        if (date.length() != 10)
+            return false;
+        try {
+            String[] dateParts = date.split("/");
+            LocalDate dateOk = LocalDate.of(Integer.parseInt(dateParts[2]), Integer.parseInt(dateParts[1]), Integer.parseInt(dateParts[0]));
+            return dateOk.getYear() > 0;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private Boolean isValidCompetitorsQuantity(Integer competitors) {
+        for (int i = competitors; i > 1; i /= 2) {
+            if (i % 2 != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/src/main/java/com/geo/challenge/service/impl/TournamentManagementServiceImpl.java
+++ b/src/main/java/com/geo/challenge/service/impl/TournamentManagementServiceImpl.java
@@ -1,0 +1,150 @@
+package com.geo.challenge.service.impl;
+
+import com.geo.challenge.dto.request.TournamentGeneratorRequest;
+import com.geo.challenge.dto.request.TournamentRandomGeneratorRequest;
+import com.geo.challenge.dto.request.TournamentRequest;
+import com.geo.challenge.dto.response.TournamentResponse;
+import com.geo.challenge.exception.GenericException;
+import com.geo.challenge.exception.TournamentException;
+import com.geo.challenge.mapper.TournamentMapper;
+import com.geo.challenge.model.Player;
+import com.geo.challenge.model.Tournament;
+import com.geo.challenge.model.TournamentPhase;
+import com.geo.challenge.model.TournamentPhaseGame;
+import com.geo.challenge.service.PlayerService;
+import com.geo.challenge.service.RequestValidator;
+import com.geo.challenge.service.TournamentManagementService;
+import com.geo.challenge.service.TournamentService;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.*;
+
+import static com.geo.challenge.constant.ConstantValues.MALE;
+import static com.geo.challenge.constant.ErrorCodes.*;
+
+@Service
+public class TournamentManagementServiceImpl implements TournamentManagementService {
+
+    private final RequestValidator requestValidator;
+    private final TournamentService tournamentService;
+    private final TournamentMapper tournamentMapper;
+    private final PlayerService playerService;
+
+    private final Random random = new Random();
+
+    public TournamentManagementServiceImpl(RequestValidator requestValidator, TournamentService tournamentService, TournamentMapper tournamentMapper, PlayerService playerService) {
+        this.requestValidator = requestValidator;
+        this.tournamentService = tournamentService;
+        this.tournamentMapper = tournamentMapper;
+        this.playerService = playerService;
+    }
+
+    @Override
+    public TournamentResponse generateRandomTournament(TournamentRandomGeneratorRequest request) {
+        requestValidator.validateTournamentRandomGeneratorRequest(request);
+        if (tournamentService.existsByName(request.getName()))
+            throw new TournamentException(TOURNAMENT_NAME_DUPLICATED.getCode(),
+                    String.format(TOURNAMENT_NAME_DUPLICATED.getDescription(), request.getName()));
+        if (playerService.countByGender(request.getType()) < request.getCompetitors())
+            throw new TournamentException(TOURNAMENT_NOT_ENOUGH_DATA.getCode(), TOURNAMENT_NOT_ENOUGH_DATA.getDescription());
+        Tournament response = new Tournament();
+        response.setName(request.getName());
+        response.setType(request.getType());
+        response.setCompetitors(request.getCompetitors());
+        String[] dateParts = request.getDate().split("/");
+        response.setDate(Date.valueOf(LocalDate.of(Integer.parseInt(dateParts[2]), Integer.parseInt(dateParts[1]), Integer.parseInt(dateParts[0]))));
+        List<Player> players = playerService.findRandomPlayers(request.getCompetitors(), request.getType());
+        completePhases(response, players);
+        Tournament savedTournament = tournamentService.save(response);
+        return tournamentMapper.tournamentToTournamentResponse(savedTournament);
+    }
+
+    @Override
+    public TournamentResponse generateTournament(TournamentGeneratorRequest request) {
+        requestValidator.validateTournamentGeneratorRequest(request);
+        if (tournamentService.existsByName(request.getName()))
+            throw new TournamentException(TOURNAMENT_NAME_DUPLICATED.getCode(),
+                    String.format(TOURNAMENT_NAME_DUPLICATED.getDescription(), request.getName()));
+        Tournament response = new Tournament();
+        response.setName(request.getName());
+        response.setType(request.getType());
+        response.setCompetitors(request.getPlayerIds().size());
+        String[] dateParts = request.getDate().split("/");
+        response.setDate(Date.valueOf(LocalDate.of(Integer.parseInt(dateParts[2]), Integer.parseInt(dateParts[1]), Integer.parseInt(dateParts[0]))));
+        List<Player> players = playerService.findPlayersByIds(request.getPlayerIds(), request.getType());
+        if (players.size() != request.getPlayerIds().size())
+            throw new TournamentException(PARTIAL_PLAYER_DATA.getCode(), PARTIAL_PLAYER_DATA.getDescription());
+        completePhases(response, players);
+        Tournament savedTournament = tournamentService.save(response);
+        return tournamentMapper.tournamentToTournamentResponse(savedTournament);
+    }
+
+    @Override
+    public TournamentResponse getTournament(TournamentRequest request) {
+        requestValidator.validateTournamentRequest(request);
+        Tournament result;
+        if (Objects.isNull(request.getName())) {
+            if (Objects.isNull(request.getType()) && tournamentService.countByDate(request.getDate()) > 1)
+                throw new TournamentException(MULTIPLE_RESULT_ERROR.getCode(), MULTIPLE_RESULT_ERROR.getDescription());
+            else if (Objects.nonNull(request.getType()) && tournamentService.countByDateAndType(request.getDate(), request.getType()) > 1)
+                throw new TournamentException(MULTIPLE_RESULT_ERROR.getCode(), MULTIPLE_RESULT_ERROR.getDescription());
+            if (Objects.isNull(request.getType()))
+                result = tournamentService.findByDate(request.getDate());
+            else
+                result = tournamentService.findByDateAndType(request.getDate(), request.getType());
+        } else {
+            result = tournamentService.findByName(request.getName());
+        }
+        if (Objects.isNull(result))
+            throw new GenericException(HttpStatus.NOT_FOUND, TOURNAMENT_NOT_FOUND.getCode(), TOURNAMENT_NOT_FOUND.getDescription());
+        return tournamentMapper.tournamentToTournamentResponse(result);
+    }
+
+    private void completePhases(Tournament tournament, List<Player> players) {
+        Integer phaseCount = 0;
+        while (Objects.isNull(tournament.getWinner())) {
+            TournamentPhase phase = new TournamentPhase();
+            Set<Integer> toRemove = new HashSet<>();
+            phase.setPhaseNumber(phaseCount);
+            phase.setTournament(tournament);
+            for (int i = 0; i < players.size(); i += 2) {
+                phase.addGame(getGameResult(players.get(i), players.get(i + 1), phase, toRemove));
+            }
+            tournament.addPhase(phase);
+            phaseCount++;
+            players.removeIf(player -> toRemove.contains(player.getPlayerId()));
+            if (players.size() == 1)
+                tournament.setWinner(players.get(0));
+        }
+    }
+
+    private TournamentPhaseGame getGameResult(Player player1, Player player2, TournamentPhase phase, Set<Integer> toRemove) {
+        Double points1 = getPoints(player1);
+        Double points2 = getPoints(player2);
+        TournamentPhaseGame gameRecord;
+        try {
+            if (points1 > points2) {
+                gameRecord = new TournamentPhaseGame(null, (Player) player1.clone(), (Player) player2.clone(), phase);
+                toRemove.add(player2.getPlayerId());
+            } else if (points2 > points1) {
+                gameRecord = new TournamentPhaseGame(null, (Player) player2.clone(), (Player) player1.clone(), phase);
+                toRemove.add(player1.getPlayerId());
+            } else {
+                gameRecord = getGameResult(player1, player2, phase, toRemove);
+            }
+        } catch (CloneNotSupportedException ex) {
+            throw new GenericException(HttpStatus.INTERNAL_SERVER_ERROR, UNEXPECTED_ERROR.getCode(), UNEXPECTED_ERROR.getDescription());
+        }
+        return gameRecord;
+    }
+
+    private Double getPoints(Player player) {
+        if (player.getGender().equalsIgnoreCase(MALE))
+            return player.getSkill() + player.getSpeed() + player.getStrength() / 2 + random.nextInt(51);
+        else
+            return player.getSkill() + (1 - player.getReactionTime()) * 50 + random.nextInt(51);
+    }
+}

--- a/src/main/java/com/geo/challenge/service/impl/TournamentServiceImpl.java
+++ b/src/main/java/com/geo/challenge/service/impl/TournamentServiceImpl.java
@@ -1,0 +1,69 @@
+package com.geo.challenge.service.impl;
+
+import com.geo.challenge.model.Tournament;
+import com.geo.challenge.repository.TournamentPhaseGameRepository;
+import com.geo.challenge.repository.TournamentPhaseRepository;
+import com.geo.challenge.repository.TournamentRepository;
+import com.geo.challenge.service.TournamentService;
+import org.springframework.stereotype.Service;
+
+import java.sql.Date;
+import java.time.LocalDate;
+
+@Service
+public class TournamentServiceImpl implements TournamentService {
+
+    private final TournamentRepository tournamentRepository;
+    private final TournamentPhaseRepository tournamentPhaseRepository;
+    private final TournamentPhaseGameRepository tournamentPhaseGameRepository;
+
+    public TournamentServiceImpl(TournamentRepository tournamentRepository, TournamentPhaseRepository tournamentPhaseRepository, TournamentPhaseGameRepository tournamentPhaseGameRepository) {
+        this.tournamentRepository = tournamentRepository;
+        this.tournamentPhaseRepository = tournamentPhaseRepository;
+        this.tournamentPhaseGameRepository = tournamentPhaseGameRepository;
+    }
+
+    @Override
+    public Boolean existsByName(String name) {
+        return tournamentRepository.existsByName(name);
+    }
+
+    @Override
+    public Integer countByDate(String date) {
+        return tournamentRepository.countByDate(getDate(date));
+    }
+
+    @Override
+    public Integer countByDateAndType(String date, String type) {
+        return tournamentRepository.countByDateAndType(getDate(date), type);
+    }
+
+    @Override
+    public Tournament findByDate(String date) {
+        return tournamentRepository.findByDate(getDate(date));
+    }
+
+    @Override
+    public Tournament findByDateAndType(String date, String type) {
+        return tournamentRepository.findByDateAndType(getDate(date), type);
+    }
+
+    @Override
+    public Tournament findByName(String name) {
+        return tournamentRepository.findByName(name);
+    }
+
+    @Override
+    public Tournament save(Tournament tournament) {
+        Tournament saved = tournamentRepository.save(tournament);
+        saved.setPhases(tournamentPhaseRepository.saveAll(tournament.getPhases()));
+        saved.getPhases().forEach(phase -> phase.setGames(tournamentPhaseGameRepository.saveAll(phase.getGames())));
+        return saved;
+    }
+
+    private Date getDate(String stringDate) {
+        String[] dateParts = stringDate.split("/");
+        LocalDate date = LocalDate.of(Integer.parseInt(dateParts[2]), Integer.parseInt(dateParts[1]), Integer.parseInt(dateParts[0]));
+        return Date.valueOf(date);
+    }
+}


### PR DESCRIPTION
Se agregan endpoints para generar torneos de forma aleatoria (usando los jugadores de la base de datos al azar) o bien, según una lista de id de jugadores de modo que los datos se validen con la base de datos